### PR TITLE
Fixed small parser issue in cylinder_error

### DIFF
--- a/src/parser/object_error.c
+++ b/src/parser/object_error.c
@@ -44,7 +44,7 @@ int	cylinder_error(char **elem)
 {
 	if (array_len(elem) != 6)
 		return (ft_putendl_fd(\
-	"Error: Plane needs 5 parameters: coordinates, vectors, diameter, height, \
+	"Error: Cylinder needs 5 parameters: coordinates, vectors, diameter, height, \
 color", 2), 1);
 	if (check_xyz(elem[1], elem[0], "coordinate"))
 		return (1);


### PR DESCRIPTION
Should be 'Cylinder' instead of 'Plane'